### PR TITLE
Fix implicit conversion warning in library header.

### DIFF
--- a/API/Z80.h
+++ b/API/Z80.h
@@ -820,11 +820,11 @@ static Z_INLINE zuint8 z80_out_cycle(Z80 const *self)
 	{
 	return self->data.uint8_array[0] == 0xD3
 		? /* out (BYTE),a : 4+3 */
-		7
+		(zuint8)7
 		: /* out (c),J / out (c),0 : 4+4 */
-		8
+		(zuint8)8
 		+ /* outi / outd / otir / otdr : 4+5+3 */
-		((self->data.uint8_array[1] >> 7) << 2);
+		(zuint8)((self->data.uint8_array[1] >> 7) << 2);
 	}
 
 


### PR DESCRIPTION
## Description

It may happen that one desires to enable the `-Wconversion` gcc flag when compiling their application, but the `Z80.h` header of this library has some legitimate (but implicit, and thus potentially harmful) conversions, which make the compilation noisy.
This trivial patch makes those conversions explicit, and avoids triggering the warning.

Tested with gcc 13.1.1

## Legal notice (do not delete)

Thank you for your contribution to the Z80 library.

It is required that contributors assign copyright to the original author so that he retains full ownership of the project. This makes it easier for other entities to use the software because they only have to deal with one copyright holder. It also gives the original author assurance that he will be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Z80 library and its copyright holder, Manuel Sainz de Baranda y Goñi, to be licensed under the same terms as the rest of the code. You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
