### PR TITLE
[Z80.c] typo in comment (trivial)

### DIFF
--- a/sources/Z80.c
+++ b/sources/Z80.c
@@ -2662,7 +2662,7 @@ Z80_API zusize z80_run(Z80 *self, zusize cycles)
 
 						/*------------------------------------------------------------------------.
 						| The `Z80::fetch` callback is temporarily replaced by a trampoline that  |
-						| invokes `Z80::int_fecth`. This trampoline needs to access the callback  |
+						| invokes `Z80::int_fetch`. This trampoline needs to access the callback  |
 						| pointer in addition to the initial, non-incremented value of PC, so the |
 						| value of `Z80::context` is temporarily replaced by a pointer to an	  |
 						| `IM0` object that holds the real context and all this data, which also  |


### PR DESCRIPTION
As noted in the title.

---

### Legal notice _(do not delete)_

Contributors are required to assign copyright to the original author of the project so that he retains full ownership. This ensures that other entities can use the software more easily, as they only need to deal with a single copyright holder. It also provides the original author with the assurance that he can make decisions in the future without needing to consult or obtain consent from all contributors.

By submitting this pull request (PR), you agree to the following:

> You hereby assign the copyright in the code included in this pull request to the original author of the Z80 library, Manuel Sainz de Baranda y Goñi, to be licensed under the same terms as the rest of the code. You also agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
