### PR TITLE
[Z80.c] fix cycle count overwriting due to += operator

### DIFF
--- a/sources/Z80.c
+++ b/sources/Z80.c
@@ -2944,7 +2944,7 @@ Z80_API zusize z80_run(Z80 *self, zusize cycles)
 			}
 
 		R++;
-		self->cycles += insn_table[DATA[0] = FETCH_OPCODE(PC)](self);
+		self->cycles = insn_table[DATA[0] = FETCH_OPCODE(PC)](self) + self->cycles;
 		}
 
 	R = R_ALL; /* Restore R7 bit. */


### PR DESCRIPTION
This is one example of code where the attempt to increase the cycle count is incorrect due to the use of the `+=` operator. (There may be others)

There are opcode calls such as `dd_prefix` and `fd_prefix` which internally increase the cycle count. Any such changes will be discarded/ignored, because the outer `+=` operator has already captured the prior value of `self->cycles` locally, meaning the addition will be based on that earlier value, and will not include any increase of the `self->cycles` value that occurred inside the opcode.

Assuming that both the explicit opcode increase of the cycle count **and** the returned value from the opcode function are both meant to be added, the fix shown in this PR is one way to solve the problem.

---

### Legal notice _(do not delete)_

Contributors are required to assign copyright to the original author of the project so that he retains full ownership. This ensures that other entities can use the software more easily, as they only need to deal with a single copyright holder. It also provides the original author with the assurance that he can make decisions in the future without needing to consult or obtain consent from all contributors.

By submitting this pull request (PR), you agree to the following:

> You hereby assign the copyright in the code included in this pull request to the original author of the Z80 library, Manuel Sainz de Baranda y Goñi, to be licensed under the same terms as the rest of the code. You also agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
