### PR TITLE
[Z80.c] a spurious semicolon

### DIFF
--- a/sources/Z80.c
+++ b/sources/Z80.c
@@ -2038,7 +2038,7 @@ INSN(out_vc_0)
 
 /* MARK: - Instructions: Optimizations */
 
-INSN(nop_nop) {Q_0; PC += 2; return 4;}
+INSN(nop_nop) {Q_0 PC += 2; return 4;}
 
 
 /* MARK: - Instruction Function Tables */


### PR DESCRIPTION
as noted in the title.

---

### Legal notice _(do not delete)_

Contributors are required to assign copyright to the original author of the project so that he retains full ownership. This ensures that other entities can use the software more easily, as they only need to deal with a single copyright holder. It also provides the original author with the assurance that he can make decisions in the future without needing to consult or obtain consent from all contributors.

By submitting this pull request (PR), you agree to the following:

> You hereby assign the copyright in the code included in this pull request to the original author of the Z80 library, Manuel Sainz de Baranda y Goñi, to be licensed under the same terms as the rest of the code. You also agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
