### PR TITLE
CI: Run the `step-tests` workflow on macOS and Ubuntu.

### DIFF
--- a/.github/workflows/step-tests.yml
+++ b/.github/workflows/step-tests.yml
@@ -46,12 +46,23 @@ env:
 
 jobs:
   step-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install dependencies
+    - name: Install dependencies (macOS)
+      if: startsWith(matrix.os, 'macos')
+      run: |
+        brew install cjson
+        brew install redcode/zxe/z80insnclock
+
+    - name: Install dependencies (Ubuntu)
+      if: startsWith(matrix.os, 'ubuntu')
       run: |
         curl -L https://zxe.io/scripts/add-zxe-apt-repo.sh | sudo sh
         sudo apt-get update
@@ -61,8 +72,9 @@ jobs:
     - name: Fetch test files
       run: |
         mkdir -p "${{ github.workspace }}/build/step-tests"
-        curl -L $(curl -L -s "${{ env.TEST_FILES_QUERY_URL }}" | grep tarball_url | cut -d ":" -f 2,3 | tr -d '" ,') |
-        gzip -cd | tar -C "${{ github.workspace }}/build/step-tests" --strip-components=2 -xf - --wildcards "${{ env.TEST_FILES_PATH }}"
+        curl -L $(curl -sL "${{ env.TEST_FILES_QUERY_URL }}" | jq -r '.tarball_url') |
+        gzip -cd |
+        tar -C "${{ github.workspace }}/build/step-tests" --strip-components=2 -xf - $([[ $(tar --version | head -n 1 | cut -d " " -f 1) = tar ]] && echo --wildcards) "${{ env.TEST_FILES_PATH }}"
 
     - name: Configure CMake
       run: >-


### PR DESCRIPTION
This re-enables the `step-tests` workflow on macOS. It was disabled because there is a bug in the `macos-latest` runner that causes the old script to fail.

### Legal notice _(do not delete)_

Contributors are required to assign copyright to the original author of the project so that he retains full ownership. This ensures that other entities can use the software more easily, as they only need to deal with a single copyright holder. It also provides the original author with the assurance that he can make decisions in the future without needing to consult or obtain consent from all contributors.

By submitting this pull request (PR), you agree to the following:

> You hereby assign the copyright in the code included in this pull request to the original author of the Z80 library, Manuel Sainz de Baranda y Goñi, to be licensed under the same terms as the rest of the code. You also agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
